### PR TITLE
verifying checksum only with posted inputs.

### DIFF
--- a/src/Providers/PaytmWalletProvider.php
+++ b/src/Providers/PaytmWalletProvider.php
@@ -45,8 +45,8 @@ class PaytmWalletProvider implements ProviderContract {
 
 	public function response(){
 		$checksum = $this->request->get('CHECKSUMHASH');
-		if(verifychecksum_e($this->request->all(), $this->merchant_key, $checksum) == "TRUE"){
-		    return $this->response = $this->request->all();
+		if(verifychecksum_e($this->request->post(), $this->merchant_key, $checksum) == "TRUE"){
+		    return $this->response = $this->request->post();
 		}
         	throw new \Exception('Invalid checksum');
 	}


### PR DESCRIPTION
Changing from `request->all()` to `request->post()`  for verifying only posted input. In some cases callback URL may have some user defined parameters. in that case it wont be showing invalid checksum.