### PR TITLE
Readme updated with Laravel 7 same_site instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ On your `config/services.php` add the following configuration
 ```
 Note : All the credentials mentioned are provided by Paytm after signing up as merchant.
 
+#### Laravel 7 Changes
+Our package is comptible with Laravel 7 but same_site setting is changed in default Laravel installation, make sure you change `same_site` to `null` in `config/session.php` or callback won't include cookies and you will be logged out when a payment is completed
+
+```php
+<?php
+
+use Illuminate\Support\Str;
+
+return [
+  /...
+  'same_site' => null,
+];
+```
+
 ## Usage
 
 


### PR DESCRIPTION
With Laravel 7, default same_site setting in `config/sesstion.php` is changed to `lax`, by default `lax` and `strict` cookies are not sent when a post request is made by a third party domain, PayTM makes a post request on payment completion and that request doesn't include cookies so Laravel sends new cookies on response assuming you're a guest user so user end up logged out when a payment is completed. I have only included instructions in README to update sessions setting to null, if you have a better way to do this than feel free to reject this PR.